### PR TITLE
removed Image from the mobile menu list

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -126,7 +126,7 @@ const Navbar = () => {
 						variants={listVariants}
 						initial='closed'
 						animate='opened'
-						className='absolute top-0 left-0 w-screen h-screen bg-black text-white flex flex-col items-center justify-center gap-8 text-4xl'>
+						className='absolute top-0 left-0 w-screen h-screen bg-black text-white flex flex-col items-center justify-center gap-8 text-4xl z-40'>
 						{links.map(({ url, title }) => (
 							<Link href={url} key={title}>
 								{title}


### PR DESCRIPTION
I removed the image that was overlapping with the mobile menu list in the mobile responsive view using the z index code of 40.