### PR TITLE
Implemented animation transition first before page loads

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,7 +1,17 @@
+'use client';
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const AboutPage = () => {
-	return <div>About Component</div>;
+	return (
+		<motion.div
+			className='h-full'
+			initial={{ y: '-200vh' }}
+			animate={{ y: '0%' }}
+			transition={{ duration: 1 }}>
+			About Component
+		</motion.div>
+	);
 };
 
 export default AboutPage;

--- a/src/app/contact/page.jsx
+++ b/src/app/contact/page.jsx
@@ -1,7 +1,17 @@
+'use client';
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const ContactPage = () => {
-	return <div>Contact Component</div>;
+	return (
+		<motion.div
+			className='h-full'
+			initial={{ y: '-200vh' }}
+			animate={{ y: '0%' }}
+			transition={{ duration: 1 }}>
+			<div>Contact Component</div>
+		</motion.div>
+	);
 };
 
 export default ContactPage;

--- a/src/app/portfolio/page.jsx
+++ b/src/app/portfolio/page.jsx
@@ -1,7 +1,17 @@
+'use client';
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const PortfolioPage = () => {
-	return <div>Portfolio Component</div>;
+	return (
+		<motion.div
+			className='h-full'
+			initial={{ y: '-200vh' }}
+			animate={{ y: '0%' }}
+			transition={{ duration: 1 }}>
+			<div>Portfolio Component</div>
+		</motion.div>
+	);
 };
 
 export default PortfolioPage;


### PR DESCRIPTION
I implemented the animation transition loading first before the page loads for the `about`, `contact`, and `portfolio` pages. This should act the same way as the `Home` page.