### PR TITLE
Implemented sending email via contact page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/app/contact/page.jsx
+++ b/src/app/contact/page.jsx
@@ -1,6 +1,7 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import emailjs from '@emailjs/browser';
 
 const ContactPage = () => {
 	const [success, setSuccess] = useState(false);
@@ -8,6 +9,35 @@ const ContactPage = () => {
 	const [error, setError] = useState(false);
 
 	const text = 'Say Hello';
+
+	const form = useRef();
+
+	const sendEmail = (e) => {
+		e.preventDefault();
+		setError(false);
+		setSuccess(false);
+
+		emailjs
+			.sendForm(
+				process.env.NEXT_PUBLIC_SERVICE_ID,
+				process.env.NEXT_PUBLIC_TEMPLATE_ID,
+				form.current,
+				{
+					publicKey: process.env.NEXT_PUBLIC_PUBLIC_KEY,
+				}
+			)
+			.then(
+				() => {
+					setSuccess(true);
+					console.log('SUCCESS');
+					form.current.reset();
+				},
+				(error) => {
+					setError(true);
+					console.log('FAILED...', error.text);
+				}
+			);
+	};
 
 	return (
 		<motion.div
@@ -37,17 +67,20 @@ const ContactPage = () => {
 				</div>
 				{/* FORM CONTAINER */}
 				<form
+					ref={form}
+					onSubmit={sendEmail}
 					className='h-1/2 lg:h-full lg:w-1/2 bg-red-50 rounded-xl text-xl flex flex-col gap-4 p-2 mb-4 
 				md:mb-0 md:gap-6 md:p-6 md:justify-center '>
 					<span>Dear Ejike,</span>
 					<textarea
-						name=''
+						name='user_message'
 						id=''
 						rows={12}
 						className='bg-transparent border-b-2 border-b-black outline-none resize-none'
 					/>
 					<span>My email address is:</span>
 					<input
+						name='user_email'
 						type='text'
 						className='bg-transparent border-b-2 border-b-black outline-none'
 					/>


### PR DESCRIPTION
I completed the implementation of sending emails via the Contact page.  I set up `Emailjs` library, created an email template, 
edited the template to add `{{user_name}}` and `{{user_message}}`, I passed `user_name` into the `input` component of the contact page `form` and passed `user_message` into the `textarea` component of the contact page `form`.
I then installed `@emailjs/browser` in my project and imported `emailjs` from it, which I used in the `sendEmail` method.
I passed the `sendEmail` method into the `onSubmit` hook in the `form`.
Not forgetting, I copied my `Public key`, `Template ID`, and `SERVICE ID` from `Emailjs app dashboard` and pasted them into the `.env` file in the project.